### PR TITLE
Strip whitespace from $arch and use cl.exe instead of "cl".

### DIFF
--- a/gas-preprocessor.pl
+++ b/gas-preprocessor.pl
@@ -217,6 +217,8 @@ if (!$arch) {
 
 # assume we're not cross-compiling if no -arch or the binary doesn't have the arch name
 $arch = qx/arch/ if (!$arch);
+# remove any whitespace, e.g. arch command might print a newline
+$arch =~ s/\s+//g;
 
 die "Unknown target architecture '$arch'" if not exists $canonical_arch{$arch};
 


### PR DESCRIPTION
The output of the "arch" command ends with a newline, thus not
matching any of the architectures.
When running under wsl it is necessary to specify the extension,
so prefer the full cl.exe name instead of just "cl".